### PR TITLE
Define Permutation type

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -83,8 +83,8 @@ end
 function create_pencils(topo::MPITopology{1}, data_dims, permutation::Val{true};
                         kwargs...)
     pen1 = Pencil(topo, data_dims, (2, ); kwargs...)
-    pen2 = Pencil(pen1, decomp_dims=(3, ), permute=Val((2, 1, 3)); kwargs...)
-    pen3 = Pencil(pen2, decomp_dims=(2, ), permute=Val((3, 2, 1)); kwargs...)
+    pen2 = Pencil(pen1, decomp_dims=(3, ), permute=Permutation(2, 1, 3); kwargs...)
+    pen3 = Pencil(pen2, decomp_dims=(2, ), permute=Permutation(3, 2, 1); kwargs...)
     pen1, pen2, pen3
 end
 
@@ -100,8 +100,8 @@ end
 function create_pencils(topo::MPITopology{2}, data_dims, permutation::Val{true};
                         kwargs...)
     pen1 = Pencil(topo, data_dims, (2, 3); kwargs...)
-    pen2 = Pencil(pen1, decomp_dims=(1, 3), permute=Val((2, 1, 3)); kwargs...)
-    pen3 = Pencil(pen2, decomp_dims=(1, 2), permute=Val((3, 2, 1)); kwargs...)
+    pen2 = Pencil(pen1, decomp_dims=(1, 3), permute=Permutation(2, 1, 3); kwargs...)
+    pen3 = Pencil(pen2, decomp_dims=(1, 2), permute=Permutation(3, 2, 1); kwargs...)
     pen1, pen2, pen3
 end
 

--- a/benchmarks/permutations.jl
+++ b/benchmarks/permutations.jl
@@ -38,18 +38,18 @@ function main()
     dst_view_dims = length.(dst_range)
     dst_view = view(dst, dst_range...)
 
-    bench_permutation(dst_view, Val((1, 2, 3)))
-    bench_permutation(dst_view, Val((1, 3, 2)))
+    bench_permutation(dst_view, Permutation(1, 2, 3))
+    bench_permutation(dst_view, Permutation(1, 3, 2))
 
-    bench_permutation(dst_view, Val((2, 1, 3)))
-    bench_permutation(dst_view, Val((2, 3, 1)))
+    bench_permutation(dst_view, Permutation(2, 1, 3))
+    bench_permutation(dst_view, Permutation(2, 3, 1))
 
-    bench_permutation(dst_view, Val((3, 1, 2)))
-    bench_permutation(dst_view, Val((3, 2, 1)))
+    bench_permutation(dst_view, Permutation(3, 1, 2))
+    bench_permutation(dst_view, Permutation(3, 2, 1))
 end
 
 function bench_permutation(dst::AbstractArray{T,N},
-                           pval::Val{perm}) where {T,N,perm}
+                           pval::Permutation{perm}) where {T,N,perm}
     iperm = invperm(perm)
     Ndst = length(dst)
     src_vec = zeros(T, 2Ndst)

--- a/docs/src/PencilArrays.md
+++ b/docs/src/PencilArrays.md
@@ -123,22 +123,23 @@ which corresponds to the permutation `(2, 3, 1)`.
 
 Permutations are passed to the `Pencil` constructor via the `permute` keyword
 argument.
-For performance reasons, in the `PencilArrays` module, dimension permutations are
-compile-time constants, and thus permutations should be specified as [value
-types](https://docs.julialang.org/en/latest/manual/types/#%22Value-types%22-1)
-wrapping a tuple.
+For performance reasons, dimension permutations are compile-time constants, and
+they should be specified using the [`Permutation`](@ref) type defined in
+`PencilArrays`.
 For instance,
 ```julia
-permutation = Val((2, 3, 1))
+permutation = Permutation(2, 3, 1)
 pencil = Pencil(#= ... =#, permute=permutation)
 ```
-One can also pass `nothing` as a permutation, which disables permutations (this
-is the default).
+One can also pass [`NoPermutation`](@ref) as a permutation, which disables
+permutations (this is the default).
 
 ### Types
 
 ```@docs
 Pencil
+Permutation
+NoPermutation
 ```
 
 ### Methods

--- a/docs/src/examples/gradient.md
+++ b/docs/src/examples/gradient.md
@@ -216,7 +216,7 @@ rng = axes(θ_glob)  # = (i1:i2, j1:j2, k1:k2)
 # it is usually in Julia.
 # If the permutation is not (3, 2, 1), things will still work (well, except for
 # the assertion below!), but the loop order will not be optimal.
-@assert get_permutation(θ_hat) === Val((3, 2, 1))
+@assert get_permutation(θ_hat) === Permutation(3, 2, 1)
 
 @inbounds for i in rng[1], j in rng[2], k in rng[3]
     kx = kvec[1][i]

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -159,8 +159,7 @@ A great deal of work has been spent in making generic index permutations as
 efficient as possible, both in intermediate and in the output state of the
 multidimensional transforms.
 This has been achieved, in part, by making sure that permutations such as `(3,
-2, 1)` are compile-time constants (using [value
-types](https://docs.julialang.org/en/latest/manual/types/#%22Value-types%22-1)).
+2, 1)` are compile-time constants.
 
 ## Further reading
 

--- a/examples/gradient.jl
+++ b/examples/gradient.jl
@@ -90,7 +90,7 @@ function gradient_global_view_explicit!(∇θ_hat::NTuple{3,PencilArray},
 
     # Note: since the dimensions in Fourier space are permuted as (z, y, x), it
     # is faster to loop with `k` as the fastest index.
-    @assert get_permutation(θ_hat) === Val((3, 2, 1))
+    @assert get_permutation(θ_hat) === Permutation(3, 2, 1)
 
     @inbounds for i in rng[1], j in rng[2], k in rng[3]
         # Wave number vector associated to current Cartesian index.
@@ -167,7 +167,7 @@ function gradient_local_linear!(∇θ_hat::NTuple{3,PencilArray},
     # indices in the Fourier-transformed arrays. By default, the memory order in
     # Fourier space is (z, y, x) instead of (x, y, z), but this is never assumed
     # below. The wave numbers must be permuted accordingly.
-    perm = get_permutation(θ_hat)  # e.g. Val((3, 2, 1))
+    perm = get_permutation(θ_hat)  # e.g. Permutation(3, 2, 1)
     kvec_perm = PA.permute_indices(kvec_local, perm)  # e.g. (kz, ky, kx)
 
     # Create wave number iterator.
@@ -199,7 +199,7 @@ end
 # It's basically the same but probably easier to understand.
 function gradient_local_linear_explicit!(∇θ_hat::NTuple{3,PencilArray},
                                          θ_hat::PencilArray, kvec_local)
-    @assert get_permutation(θ_hat) === Val((3, 2, 1))
+    @assert get_permutation(θ_hat) === Permutation(3, 2, 1)
 
     # Create wave number iterator in (kz, ky, kx) order, i.e. in the same order
     # as the array data.

--- a/src/PencilArrays/PencilArrays.jl
+++ b/src/PencilArrays/PencilArrays.jl
@@ -16,6 +16,7 @@ import LinearAlgebra
 
 export Transpositions
 
+export Permutation, NoPermutation
 export Pencil, PencilArray, MPITopology
 export PencilArrayCollection
 export ManyPencilArray
@@ -35,6 +36,7 @@ using .MPITopologies
 import .MPITopologies: get_comm
 
 # Type definitions
+include("types.jl")        # Permutation
 include("pencil.jl")       # Pencil
 include("arrays.jl")       # PencilArray
 include("multiarrays.jl")  # ManyPencilArray

--- a/src/PencilArrays/Transpositions.jl
+++ b/src/PencilArrays/Transpositions.jl
@@ -475,7 +475,7 @@ end
 
 function copy_permuted!(dest::PencilArray{T,N}, o_range_iperm::ArrayRegion{P},
                         src::Vector{T}, src_offset::Int,
-                        perm::Union{Nothing, Val}, extra_dims::Dims{E},
+                        perm::Permutation, extra_dims::Dims{E},
                         timer) where {T,N,P,E}
     @assert P + E == N
 
@@ -489,7 +489,7 @@ function copy_permuted!(dest::PencilArray{T,N}, o_range_iperm::ArrayRegion{P},
     dest_view = let dest_p = parent(dest)  # array with non-permuted indices
         indices = permute_indices(o_range_iperm, perm)
         v = view(dest_p, indices..., Base.OneTo.(extra_dims)...)
-        if perm === nothing
+        if perm isa NoPermutation
             v
         else
             p = append_to_permutation(perm, Val(E))

--- a/src/PencilArrays/arrays.jl
+++ b/src/PencilArrays/arrays.jl
@@ -334,7 +334,7 @@ get_comm(x::MaybePencilArrayCollection) = get_comm(pencil(x))
 
 Get index permutation associated to the given `PencilArray`.
 
-Returns `nothing` if there is no associated permutation.
+Returns `NoPermutation()` if there is no associated permutation.
 """
 function get_permutation(x::MaybePencilArrayCollection)
     perm = get_permutation(pencil(x))

--- a/src/PencilArrays/arrays.jl
+++ b/src/PencilArrays/arrays.jl
@@ -378,7 +378,7 @@ function gather(x::PencilArray{T,N}, root::Integer=0) where {T, N}
             x.data
         else
             # Apply inverse permutation.
-            invperm = relative_permutation(perm, nothing)
+            invperm = inverse_permutation(perm)
             p = append_to_permutation(invperm, Val(length(extra_dims)))
             permutedims(x.data, extract(p))  # creates copy!
         end

--- a/src/PencilArrays/pencil.jl
+++ b/src/PencilArrays/pencil.jl
@@ -189,7 +189,7 @@ get_comm(p::Pencil) = get_comm(p.topology)
 
 Get index permutation associated to the given pencil configuration.
 
-Returns `nothing` if there is no associated permutation.
+Returns `NoPermutation()` if there is no associated permutation.
 """
 get_permutation(p::Pencil) = p.perm
 

--- a/src/PencilArrays/permutations.jl
+++ b/src/PencilArrays/permutations.jl
@@ -1,29 +1,33 @@
 ## Permutation operations ##
 
-const Permutation{N} = NTuple{N,Int} where N
+# This is useful for base functions that don't accept permutations as value
+# types (like `permutedims!`).
+extract(::Permutation{p}) where {p} = p
 
-is_valid_permutation(::Nothing) = true
-is_valid_permutation(::Val{P}) where {P} = isa(P, Permutation) && isperm(P)
+Base.length(::Permutation{p,N}) where {p,N} = N
+
+is_valid_permutation(::NoPermutation) = true
+is_valid_permutation(::Permutation{P}) where {P} = isperm(P)
 is_valid_permutation(::Any) = false
 
 function check_permutation(perm)
     if !is_valid_permutation(perm)
-        s = perm isa Permutation ?
-            ".\nHint: passing Val($perm) may fix this." : ""
+        s = perm isa Permutation ? "" :
+            ".\nHint: passing Permutation($perm) may fix this."
         throw(ArgumentError("invalid permutation of dimensions: $perm$s"))
     end
     nothing
 end
 
 # Permute tuple values.
-@inline permute_indices(t::Tuple, ::Nothing) = t
+@inline permute_indices(t::Tuple, ::NoPermutation) = t
 @inline permute_indices(t::Tuple, p::Pencil) = permute_indices(t, p.perm)
 @inline function permute_indices(t::Tuple{Vararg{Any,N}},
-                                 ::Val{perm}) where {N, perm}
-    perm :: Permutation{N}
+                                 ::Permutation{perm,N}) where {N, perm}
     @inbounds ntuple(i -> t[perm[i]], Val(N))
 end
-@inline permute_indices(::Val{t}, p::Val) where {t} = Val(permute_indices(t, p))
+@inline permute_indices(::Permutation{t}, p::Permutation) where {t} =
+    Permutation(permute_indices(t, p)...)
 
 @inline permute_indices(I::CartesianIndex, perm) =
     CartesianIndex(permute_indices(Tuple(I), perm))
@@ -32,63 +36,54 @@ end
 # that `permute_indices(x, perm) == y`.
 # It is assumed that both tuples have the same elements, possibly in different
 # order.
-function relative_permutation(x::Val{p}, y::Val{q}) where {p, q}
-    N = length(p)
-    p :: Permutation{N}
-    q :: Permutation{N}
+function relative_permutation(x::Permutation{p,N},
+                              y::Permutation{q,N}) where {p, q, N}
     if @generated
         perm = map(v -> findfirst(==(v), p)::Int, q)
-        @assert permute_indices(p, Val(perm)) === q
-        :( Val($perm) )
+        @assert permute_indices(p, Permutation(perm)) === q
+        :( Permutation($perm) )
     else
         perm = map(v -> findfirst(==(v), p)::Int, q)
-        @assert permute_indices(p, Val(perm)) === q
-        Val(perm)
+        @assert permute_indices(p, Permutation(perm)) === q
+        Permutation(perm)
     end
 end
 
-relative_permutation(::Nothing, y::Val) = y
-relative_permutation(::Nothing, ::Nothing) = nothing
+relative_permutation(::NoPermutation, y::Permutation) = y
+relative_permutation(::NoPermutation, y::NoPermutation) = y
 
 # In this case, the result is the inverse permutation of `x`, such that
 # `permute_indices(x, perm) == (1, 2, 3, ...)`.
 # (Same as `invperm`, which is type unstable for tuples.)
-relative_permutation(x::Val{p}, ::Nothing) where {p} =
+relative_permutation(x::Permutation{p}, ::NoPermutation) where {p} =
     relative_permutation(x, identity_permutation(Val(length(p))))
 
-inverse_permutation(x::Union{Nothing, Val}) = relative_permutation(x, nothing)
+inverse_permutation(x::Permutation) = relative_permutation(x, NoPermutation())
 
 relative_permutation(p::Pencil, q::Pencil) =
     relative_permutation(p.perm, q.perm)
 
 # Construct the identity permutation: (1, 2, 3, ...)
-identity_permutation(::Val{N}) where N = Val(ntuple(identity, N))
+identity_permutation(::Val{N}) where N = Permutation(ntuple(identity, N))
 
-is_identity_permutation(::Nothing) = true
+is_identity_permutation(::NoPermutation) = true
 
-function is_identity_permutation(::Val{P}) where P
-    N = length(P)
-    P :: Permutation{N}
-    P === identity_permutation(Val(N))
+function is_identity_permutation(perm::Permutation)
+    N = length(perm)
+    perm === identity_permutation(Val(N))
 end
 
-same_permutation(::Val{p}, ::Val{p}) where {p} = true
-same_permutation(::Val{p}, ::Val{q}) where {p, q} = (@assert p !== q; false)
-same_permutation(::Val{p}, ::Nothing) where {p} =
+same_permutation(::Permutation{p}, ::Permutation{q}) where {p, q} = p === q
+same_permutation(::NoPermutation, ::NoPermutation) = true
+same_permutation(p::Permutation, ::NoPermutation) =
     p === identity_permutation(Val(length(p)))
-same_permutation(::Nothing, p::Val) = same_permutation(p, nothing)
-same_permutation(::Nothing, ::Nothing) = true
 
 # Append `M` non-permuted dimensions to the given permutation.
-# Example: append_to_permutation(Val((2, 3, 1)), Val(2)) = Val((2, 3, 1, 4, 5)).
-function append_to_permutation(::Val{p}, ::Val{M}) where {p, M}
+# Example: append_to_permutation(Permutation((2, 3, 1)), Val(2)) =
+# Permutation((2, 3, 1, 4, 5)).
+function append_to_permutation(::Permutation{p}, ::Val{M}) where {p, M}
     N = length(p)
-    p :: Permutation{N}
-    Val((p..., ntuple(i -> N + i, Val(M))...))
+    Permutation(p..., ntuple(i -> N + i, Val(M))...)
 end
 
-append_to_permutation(::Nothing, ::Val) = nothing
-
-# This is useful for base functions that don't accept permutations as value
-# types (like `permutedims!`).
-extract(::Val{p}) where {p} = p
+append_to_permutation(np::NoPermutation, ::Val) = np

--- a/src/PencilArrays/types.jl
+++ b/src/PencilArrays/types.jl
@@ -1,0 +1,56 @@
+"""
+    Permutation{p}
+
+Describes a compile-time dimension permutation.
+
+The type parameter `p` should be a valid permutation such as `(3, 1, 2)`.
+
+The parameter `p` may also be `nothing`.
+A `Permutation{nothing}` represents an identity permutation: it is equivalent to
+`Permutation{(1, 2, …, N)}` for any number of dimensions `N`.
+The [`NoPermutation`](@ref) type is provided as an alias for
+`Permutation{nothing}`.
+
+---
+
+    Permutation(perm::Vararg{Int})
+    Permutation(perm::NTuple{N,Int})
+
+Constructs a `Permutation`.
+
+# Example
+
+Both are equivalent:
+
+```julia
+p1 = Permutation(3, 4)
+p2 = Permutation((3, 4))
+```
+
+---
+
+    Permutation(nothing)
+    NoPermutation()
+
+Constructs an identity permutation.
+"""
+struct Permutation{p, N}  # TODO do we need the N parameter?
+    Permutation{nothing, 0}() = new{nothing, 0}()
+    Permutation(perm::Vararg{Int}) = new{perm, length(perm)}()
+end
+
+Permutation(::Nothing) = Permutation{nothing, 0}()
+Permutation(perm::Tuple) = Permutation(perm...)
+
+"""
+    NoPermutation
+
+Alias for an identity permutation, i.e. `NoPermutation = Permutation{nothing}`.
+
+This alias can be called as a constructor.
+In other words, `NoPermutation()` creates a `Permutation{nothing}` as expected.
+"""
+const NoPermutation = typeof(Permutation(nothing))
+
+Base.show(io::IO, ::NoPermutation) = print(io, "None")
+Base.show(io::IO, ::Permutation{p}) where {p} = print(io, p)

--- a/src/PencilArrays/types.jl
+++ b/src/PencilArrays/types.jl
@@ -47,8 +47,8 @@ Permutation(perm::Tuple) = Permutation(perm...)
 
 Alias for an identity permutation, i.e. `NoPermutation = Permutation{nothing}`.
 
-This alias can be called as a constructor.
-In other words, `NoPermutation()` creates a `Permutation{nothing}` as expected.
+This alias can be called as a constructor:
+`NoPermutation()` creates a `Permutation{nothing}`, as expected.
 """
 const NoPermutation = typeof(Permutation(nothing))
 

--- a/test/pencils.jl
+++ b/test/pencils.jl
@@ -202,8 +202,8 @@ function main()
     topo = MPITopology(comm, proc_dims)
 
     pen1 = Pencil(topo, Nxyz, (2, 3))
-    pen2 = Pencil(pen1, decomp_dims=(1, 3), permute=Val((2, 3, 1)))
-    pen3 = Pencil(pen2, decomp_dims=(1, 2), permute=Val((3, 2, 1)))
+    pen2 = Pencil(pen1, decomp_dims=(1, 3), permute=Permutation(2, 3, 1))
+    pen3 = Pencil(pen2, decomp_dims=(1, 2), permute=Permutation(3, 2, 1))
 
     @testset "ManyPencilArray" begin
         test_multiarrays(pen1, pen2, pen3)
@@ -222,7 +222,7 @@ function main()
         @test_throws TypeError Pencil(
             topo, Nxyz, (1, 2), permute=(2, 3, 1))
         @test_throws ArgumentError Pencil(
-            topo, Nxyz, (1, 2), permute=Val((0, 3, 15)))
+            topo, Nxyz, (1, 2), permute=Permutation(0, 3, 15))
 
         # Decomposed dimensions may not be repeated.
         @test_throws ArgumentError Pencil(topo, Nxyz, (2, 2))
@@ -241,13 +241,13 @@ function main()
     @testset "auxiliary functions" begin
         @test PencilArrays.complete_dims(Val(5), (2, 3), (42, 12)) ===
             (1, 42, 12, 1, 1)
-        @test get_permutation(pen1) === nothing
-        @test get_permutation(pen2) === Val((2, 3, 1))
+        @test get_permutation(pen1) === NoPermutation()
+        @test get_permutation(pen2) === Permutation(2, 3, 1)
 
-        @test PA.relative_permutation(pen2, pen3) === Val((2, 1, 3))
+        @test PA.relative_permutation(pen2, pen3) === Permutation(2, 1, 3)
 
-        let a = Val((2, 1, 3)), b = Val((3, 2, 1))
-            @test PA.permute_indices((:a, :b, :c), Val((2, 3, 1))) ===
+        let a = Permutation((2, 1, 3)), b = Permutation((3, 2, 1))
+            @test PA.permute_indices((:a, :b, :c), Permutation((2, 3, 1))) ===
                 (:b, :c, :a)
             a2b = PA.relative_permutation(a, b)
             @test PA.permute_indices(a, a2b) === b
@@ -259,9 +259,9 @@ function main()
                 end
             end
 
-            x = Val((3, 1, 2))
-            x2nothing = PA.relative_permutation(x, nothing)
-            @test PA.permute_indices(x, x2nothing) === Val((1, 2, 3))
+            x = Permutation((3, 1, 2))
+            x2nothing = PA.relative_permutation(x, NoPermutation())
+            @test PA.permute_indices(x, x2nothing) === Permutation((1, 2, 3))
         end
     end
 
@@ -331,7 +331,7 @@ function main()
         pen2 = Pencil(pen1, decomp_dims=(2, ))
 
         # Same decomposed dimension as pen2, but different permutation.
-        pen3 = Pencil(pen2, permute=Val((3, 2, 1)))
+        pen3 = Pencil(pen2, permute=Permutation(3, 2, 1))
 
         u1 = PencilArray(pen1)
         u2 = PencilArray(pen2)
@@ -373,9 +373,10 @@ function main()
         @inferred PencilArray(pen2)
         @inferred PencilArray(pen2, (3, 4))
 
-        @inferred PA.permute_indices(Nxyz, Val((2, 3, 1)))
-        @inferred PA.relative_permutation(Val((1, 2, 3)), Val((2, 3, 1)))
-        @inferred PA.relative_permutation(Val((1, 2, 3)), nothing)
+        @inferred PA.permute_indices(Nxyz, Permutation(2, 3, 1))
+        @inferred PA.relative_permutation(Permutation(1, 2, 3),
+                                          Permutation(2, 3, 1))
+        @inferred PA.relative_permutation(Permutation(1, 2, 3), NoPermutation())
 
         u1 = PencilArray(pen1)
         u2 = PencilArray(pen2)


### PR DESCRIPTION
Dimension permutations are now defined using the new Permutation type,
instead of using value types and `nothing`.