### PR TITLE
Remove element type information from Pencil

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -146,7 +146,7 @@ function benchmark_pencils(comm, proc_dims::Tuple, data_dims::Tuple;
 
     pens = create_pencils(topo, data_dims, with_permutations, timer=to)
 
-    u = map(p -> PencilArray(p, extra_dims), pens)
+    u = map(p -> PencilArray{Float64}(undef, p, extra_dims), pens)
 
     myrank = MPI.Comm_rank(comm)
     rng = MersenneTwister(42 + myrank)

--- a/docs/src/PencilArrays.md
+++ b/docs/src/PencilArrays.md
@@ -23,11 +23,12 @@ PencilArrays
 
 ## Construction
 
-A `PencilArray` wrapper can be constructed from a [`Pencil`](@ref) instance as
+An uninitialised `PencilArray` can be constructed from a [`Pencil`](@ref)
+instance as
 ```julia
 pencil = Pencil(#= ... =#)
-A = PencilArray(pencil)
-parent(A)  # returns the allocated Array
+A = PencilArray{Float64}(undef, pencil)
+parent(A)  # returns the Array wrapped by `A`
 ```
 This allocates a new `Array` with the local dimensions and data type associated
 to the `Pencil`.

--- a/docs/src/PencilArrays.md
+++ b/docs/src/PencilArrays.md
@@ -37,9 +37,8 @@ One can also construct a `PencilArray` wrapper from an existing
 configuration.
 For instance, the following works:
 ```julia
-T = eltype(pencil)
 dims = size_local(pencil, permute=true)  # dimensions of data array must be permuted!
-data = Array{T}(undef, dims)
+data = Array{Float64}(undef, dims)
 A = PencilArray(pencil, data)
 ```
 Note that `data` does not need to be a `Array`, but can be any subtype of

--- a/docs/src/Pencils.md
+++ b/docs/src/Pencils.md
@@ -82,7 +82,6 @@ NoPermutation
 ## Methods
 
 ```@docs
-eltype(::Pencil)
 get_comm(::Pencil)
 get_decomposition(::Pencil)
 get_permutation(::Pencil)

--- a/src/PencilArrays/arrays.jl
+++ b/src/PencilArrays/arrays.jl
@@ -63,12 +63,14 @@ PencilArray{Float64}(undef, pencil)          # array dimensions are (20, 10, 30)
 PencilArray{Float64}(undef, pencil, (4, 3))  # array dimensions are (20, 10, 30, 4, 3)
 ```
 """
-struct PencilArray{T, N,
-                   A <: AbstractArray{T,N},
-                   Np,  # number of "spatial" dimensions (i.e. dimensions of the Pencil)
-                   E,   # number of "extra" dimensions (= N - Np)
-                   P <: Pencil,
-                  } <: AbstractArray{T,N}
+struct PencilArray{
+        T,
+        N,
+        A <: AbstractArray{T,N},
+        Np,  # number of "spatial" dimensions (i.e. dimensions of the Pencil)
+        E,   # number of "extra" dimensions (= N - Np)
+        P <: Pencil,
+    } <: AbstractArray{T,N}
     pencil   :: P
     data     :: A
     space_dims :: Dims{Np}  # *unpermuted* spatial dimensions

--- a/src/PencilArrays/arrays.jl
+++ b/src/PencilArrays/arrays.jl
@@ -48,7 +48,7 @@ pencil.
 
 ---
 
-    PencilArray(pencil::Pencil, [extra_dims=()])
+    PencilArray{T}(undef, pencil::Pencil, [extra_dims=()])
 
 Allocate an uninitialised `PencilArray` that can hold data in the local pencil.
 
@@ -59,8 +59,8 @@ array.
 # Example
 Suppose `pencil` has local dimensions `(20, 10, 30)` after permutation. Then:
 ```julia
-PencilArray(pencil)          # array dimensions are (20, 10, 30)
-PencilArray(pencil, (4, 3))  # array dimensions are (20, 10, 30, 4, 3)
+PencilArray{Float64}(undef, pencil)          # array dimensions are (20, 10, 30)
+PencilArray{Float64}(undef, pencil, (4, 3))  # array dimensions are (20, 10, 30, 4, 3)
 ```
 """
 struct PencilArray{T, N,
@@ -74,7 +74,7 @@ struct PencilArray{T, N,
     space_dims :: Dims{Np}  # *unpermuted* spatial dimensions
     extra_dims :: Dims{E}
 
-    function PencilArray(pencil::Pencil{Np, Mp, T} where {Np, Mp},
+    function PencilArray(pencil::Pencil{Np, Mp} where {Np, Mp},
                          data::AbstractArray{T, N}) where {T, N}
         P = typeof(pencil)
         A = typeof(data)
@@ -100,10 +100,14 @@ struct PencilArray{T, N,
     end
 end
 
-function PencilArray(pencil::Pencil, extra_dims::Dims=())
-    T = eltype(pencil)
+@deprecate(
+    PencilArray(p::Pencil, extra_dims=()),
+    PencilArray{eltype(p)}(undef, p, extra_dims),
+)
+
+function PencilArray{T}(init, pencil::Pencil, extra_dims::Dims=()) where {T}
     dims = (size_local(pencil, permute=true)..., extra_dims...)
-    PencilArray(pencil, Array{T}(undef, dims))
+    PencilArray(pencil, Array{T}(init, dims))
 end
 
 """

--- a/src/PencilIO/hdf5.jl
+++ b/src/PencilIO/hdf5.jl
@@ -140,8 +140,11 @@ The following property types are recognised:
 Open a parallel HDF5 file and write some `PencilArray`s to the file:
 
 ```julia
-u = PencilArray(...)
-v = PencilArray(...)
+pencil = Pencil(#= ... =#)
+u = PencilArray{Float64}(undef, pencil)
+v = similar(u)
+
+# [fill the arrays with interesting values...]
 
 comm = get_comm(u)
 info = MPI.Info()
@@ -210,8 +213,9 @@ The following property types are recognised:
 Open a parallel HDF5 file and read some `PencilArray`s:
 
 ```julia
-u = PencilArray(...)
-v = PencilArray(...)
+pencil = Pencil(#= ... =#)
+u = PencilArray{Float64}(undef, pencil)
+v = similar(u)
 
 comm = get_comm(u)
 info = MPI.Info()

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -195,12 +195,6 @@ function Base.show(io::IO, p::Pencil)
               Data permutation: $(perm)""")
 end
 
-"""
-    eltype(Pencil)
-    eltype(p::Pencil)
-
-Element type associated to the given pencil type.
-"""
 function Base.eltype(::Type{<:Pencil{N, M, T}}) where {N, M, T}
     Base.depwarn(
         "eltype(::Pencil) is deprecated and will be removed soon!",

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -135,7 +135,7 @@ struct Pencil{N,  # spatial dimensions
                      axes_local_perm, permute, send_buf, recv_buf, timer)
     end
 
-    function Pencil(p::Pencil{N,M}, ::Type{T}=eltype(p);
+    function Pencil(p::Pencil{N,M}, ::Type{T}=Float64;
                     decomp_dims::Dims{M}=get_decomposition(p),
                     size_global::Dims{N}=size_global(p),
                     permute=get_permutation(p),
@@ -171,7 +171,7 @@ function Base.show(io::IO, p::Pencil)
     print(io,
           """
           Decomposition of $(ndims(p))D data
-              Data dimensions: $(size_global(p)) [$(eltype(p))]
+              Data dimensions: $(size_global(p))
               Decomposed dimensions: $(get_decomposition(p))
               Data permutation: $(perm)""")
 end
@@ -182,7 +182,10 @@ end
 
 Element type associated to the given pencil type.
 """
-Base.eltype(::Type{<:Pencil{N, M, T}}) where {N, M, T} = T
+function Base.eltype(::Type{<:Pencil{N, M, T}}) where {N, M, T}
+    @warn "eltype(::Pencil) is deprecated and will be removed soon!"
+    T
+end
 
 """
     get_timer(p::Pencil)

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -26,6 +26,10 @@ import .MPITopologies: get_comm
 
 include("data_ranges.jl")
 
+# TODO
+# - remove `T` parameter
+# - remove `element_type` arguments
+
 """
     Pencil{N,M,T}
 
@@ -36,16 +40,15 @@ The `Pencil` describes the decomposition of arrays of element type `T`.
 
 ---
 
-    Pencil(topology::MPITopology{M}, size_global::Dims{N},
-           decomp_dims::Dims{M}, [element_type=Float64];
+    Pencil(topology::MPITopology{M}, size_global::Dims{N}, decomp_dims::Dims{M};
            permute::Permutation=NoPermutation(),
            timer=TimerOutput())
 
 Define the decomposition of an `N`-dimensional geometry along `M` dimensions.
 
 The dimensions of the geometry are given by `size_global = (N1, N2, ...)`. The
-`Pencil` describes the decomposition of an array of dimensions `size_global` and
-type `T` across a group of MPI processes.
+`Pencil` describes the decomposition of an array of dimensions `size_global`
+across a group of MPI processes.
 
 Data is distributed over the given `M`-dimensional MPI topology (with `M < N`).
 The decomposed dimensions are given by `decomp_dims`.
@@ -63,7 +66,7 @@ It is also possible to pass a `TimerOutput` to the constructor. See
 Decompose a 3D geometry of global dimensions ``N_x × N_y × N_z = 4×8×12`` along
 the second (``y``) and third (``z``) dimensions.
 ```julia
-Pencil(topology, (4, 8, 12), (2, 3))                          # data is in (x, y, z) order
+Pencil(topology, (4, 8, 12), (2, 3))                                # data is in (x, y, z) order
 Pencil(topology, (4, 8, 12), (2, 3), permute=Permutation(3, 2, 1))  # data is in (z, y, x) order
 ```
 In the second case, the actual data is stored in `(z, y, x)` order within
@@ -71,7 +74,7 @@ each MPI process.
 
 ---
 
-    Pencil(p::Pencil{N,M}, [element_type=eltype(p)];
+    Pencil(p::Pencil{N,M};
            decomp_dims::Dims{M}=get_decomposition(p),
            size_global::Dims{N}=size_global(p),
            permute::P=get_permutation(p),
@@ -84,7 +87,7 @@ configurations, leading to reduced global memory usage.
 """
 struct Pencil{N,  # spatial dimensions
               M,  # MPI topology dimensions (< N)
-              T <: Number,  # element type (e.g. Float64, Complex{Float64})
+              T <: Number,  # element type (e.g. Float64, Complex{Float64}) [TODO remove!]
               P,  # optional index permutation (see Permutation)
              }
     # M-dimensional MPI decomposition info (with M < N).

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -26,23 +26,23 @@ import .MPITopologies: get_comm
 
 include("data_ranges.jl")
 
-# TODO
+# TODO [deprecation]
 # - remove `T` parameter
 # - remove `element_type` arguments
 
 """
-    Pencil{N,M,T}
+    Pencil{N,M}
 
-Describes the decomposition of an `N`-dimensional Cartesian geometry among MPI
-processes along `M` directions (with `M < N`).
-
-The `Pencil` describes the decomposition of arrays of element type `T`.
+Describes the decomposition of an `N`-dimensional array among MPI processes
+along `M` directions (with `M < N`).
 
 ---
 
-    Pencil(topology::MPITopology{M}, size_global::Dims{N}, decomp_dims::Dims{M};
-           permute::Permutation=NoPermutation(),
-           timer=TimerOutput())
+    Pencil(
+        topology::MPITopology{M}, size_global::Dims{N}, decomp_dims::Dims{M};
+        permute::Permutation = NoPermutation(),
+        timer = TimerOutput(),
+    )
 
 Define the decomposition of an `N`-dimensional geometry along `M` dimensions.
 
@@ -74,22 +74,25 @@ each MPI process.
 
 ---
 
-    Pencil(p::Pencil{N,M};
-           decomp_dims::Dims{M}=get_decomposition(p),
-           size_global::Dims{N}=size_global(p),
-           permute::P=get_permutation(p),
-           timer::TimerOutput=get_timer(p))
+    Pencil(
+        p::Pencil{N,M};
+        decomp_dims::Dims{M} = get_decomposition(p),
+        size_global::Dims{N} = size_global(p),
+        permute::P = get_permutation(p),
+        timer::TimerOutput = get_timer(p),
+    )
 
 Create new pencil configuration from an existent one.
 
 This constructor enables sharing temporary data buffers between the two pencil
 configurations, leading to reduced global memory usage.
 """
-struct Pencil{N,  # spatial dimensions
-              M,  # MPI topology dimensions (< N)
-              T <: Number,  # element type (e.g. Float64, Complex{Float64}) [TODO remove!]
-              P,  # optional index permutation (see Permutation)
-             }
+struct Pencil{
+        N,  # spatial dimensions
+        M,  # MPI topology dimensions (< N)
+        T <: Number,  # element type [TODO deprecated -- remove!]
+        P,  # optional index permutation (see Permutation)
+    }
     # M-dimensional MPI decomposition info (with M < N).
     topology :: MPITopology{M}
 
@@ -121,13 +124,13 @@ struct Pencil{N,  # spatial dimensions
     # Timing information.
     timer :: TimerOutput
 
-    function Pencil(topology::MPITopology{M}, size_global::Dims{N},
-                    decomp_dims::Dims{M};
-                    permute::Permutation=NoPermutation(),
-                    send_buf=UInt8[], recv_buf=UInt8[],
-                    timer=TimerOutput(),
-                    _deprecated_eltype::Val{T} = Val(Float64),
-                   ) where {N, M, T<:Number}
+    function Pencil(
+            topology::MPITopology{M}, size_global::Dims{N}, decomp_dims::Dims{M};
+            permute::Permutation = NoPermutation(),
+            send_buf = UInt8[], recv_buf = UInt8[],
+            timer = TimerOutput(),
+            _deprecated_eltype::Val{T} = Val(Float64),
+        ) where {N, M, T<:Number}
         check_permutation(permute)
         _check_selected_dimensions(N, decomp_dims)
         decomp_dims = _sort_dimensions(decomp_dims)

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -126,7 +126,7 @@ struct Pencil{N,  # spatial dimensions
                     permute::Permutation=NoPermutation(),
                     send_buf=UInt8[], recv_buf=UInt8[],
                     timer=TimerOutput(),
-                    _deprecated_eltype::Type{T} = Float64,
+                    _deprecated_eltype::Val{T} = Val(Float64),
                    ) where {N, M, T<:Number}
         check_permutation(permute)
         _check_selected_dimensions(N, decomp_dims)
@@ -144,23 +144,23 @@ struct Pencil{N,  # spatial dimensions
                     size_global::Dims{N}=size_global(p),
                     permute=get_permutation(p),
                     timer::TimerOutput=get_timer(p),
-                    _deprecated_eltype::Type{T} = Float64,
-                   ) where {N, M, T<:Number}
+                    etc...
+                   ) where {N, M}
         Pencil(p.topology, size_global, decomp_dims;
                permute=permute, timer=timer,
                send_buf=p.send_buf, recv_buf=p.recv_buf,
-               _deprecated_eltype=T)
+               etc...)
     end
 end
 
 @deprecate(
     Pencil(topo, dims, pdims, ::Type{T}; kw...) where {T},
-    Pencil(topo, dims, pdims; kw..., _deprecated_eltype = T),
+    Pencil(topo, dims, pdims; kw..., _deprecated_eltype = Val(T)),
 )
 
 @deprecate(
     Pencil(pencil, ::Type{T}; kw...) where {T},
-    Pencil(pencil; kw..., _deprecated_eltype = T),
+    Pencil(pencil; kw..., _deprecated_eltype = Val(T)),
 )
 
 # Verify that `dims` is a subselection of dimensions in 1:N.

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -199,7 +199,10 @@ end
 Element type associated to the given pencil type.
 """
 function Base.eltype(::Type{<:Pencil{N, M, T}}) where {N, M, T}
-    @warn "eltype(::Pencil) is deprecated and will be removed soon!"
+    Base.depwarn(
+        "eltype(::Pencil) is deprecated and will be removed soon!",
+        :eltype_Pencil,
+    )
     T
 end
 

--- a/src/Pencils/Pencils.jl
+++ b/src/Pencils/Pencils.jl
@@ -138,7 +138,7 @@ struct Pencil{N,  # spatial dimensions
                      axes_local_perm, permute, send_buf, recv_buf, timer)
     end
 
-    function Pencil(p::Pencil{N,M}, ::Type{T}=Float64;
+    function Pencil(p::Pencil{N,M}, ::Type{T}=eltype(p);
                     decomp_dims::Dims{M}=get_decomposition(p),
                     size_global::Dims{N}=size_global(p),
                     permute=get_permutation(p),

--- a/src/pencil_plans.jl
+++ b/src/pencil_plans.jl
@@ -293,6 +293,7 @@ function _make_pencil_in(::Type{Ti}, g::GlobalFFTParams{T, N} where T,
                          permute_dims::ValBool,
                         ) where {Ti, N, M, n}
     Po_prev = plan_prev.pencil_out
+    @assert eltype(Po_prev) === Ti
 
     # (i) Determine permutation of pencil data.
     perm = _make_permutation_in(permute_dims, dim, Val(N))
@@ -317,8 +318,8 @@ function _make_pencil_in(::Type{Ti}, g::GlobalFFTParams{T, N} where T,
     @assert allunique(decomp)
 
     # Create new pencil sharing some information with Po_prev.
-    # (Including data type and dimensions, MPI topology and data buffers.)
-    Pencil(Po_prev, decomp_dims=decomp, permute=perm, timer=timer)
+    # (Including dimensions, MPI topology and data buffers.)
+    Pencil(Po_prev, Ti, decomp_dims=decomp, permute=perm, timer=timer)
 end
 
 # No permutations

--- a/src/pencil_plans.jl
+++ b/src/pencil_plans.jl
@@ -281,9 +281,10 @@ function _create_plans(::Type{Ti},
                          plan1d_opt.permute_dims)
 
     # Output transform along dimension `n`.
-    To = eltype_output(transform_fw, eltype(Pi))
+    To = eltype_output(transform_fw, Ti)
     Po = let dims = ntuple(j -> j ≤ n ? so[j] : si[j], Val(N))
-        if dims === size_global(Pi) && To === eltype(Pi)
+        # TODO can I remove the To === Ti?
+        if dims === size_global(Pi) && To === Ti
             Pi  # in this case Pi and Po are the same
         else
             Pencil(Pi, To, size_global=dims, timer=timer)
@@ -393,8 +394,10 @@ function _make_1d_fft_plan(dim::Val{n}, Pi::Pencil, Po::Pencil,
     # backward transforms.
     transform_bw = binv(transform_fw)
     extra_dims = plan1d_opt.extra_dims
-    A_fw = _temporary_pencil_array(Pi, plan1d_opt.ibuf, extra_dims)
-    A_bw = _temporary_pencil_array(Po, plan1d_opt.obuf, extra_dims)
+    Ti = eltype(Pi)
+    To = eltype(Po)
+    A_fw = _temporary_pencil_array(Ti, Pi, plan1d_opt.ibuf, extra_dims)
+    A_bw = _temporary_pencil_array(To, Po, plan1d_opt.obuf, extra_dims)
 
     # Scale factor to be applied after backward transform.
     # The passed array must have the dimensions of the backward transform output

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -84,7 +84,7 @@ function main()
 
     topo = MPITopology(comm, proc_dims)
     pen = Pencil(topo, Nxyz, (1, 3), permute=Permutation(2, 3, 1))
-    u = PencilArray(pen)
+    u = PencilArray{Float64}(undef, pen)
     randn!(rng, u)
     u .+= 10 * myrank
 

--- a/test/rfft.jl
+++ b/test/rfft.jl
@@ -206,16 +206,9 @@ function test_rfft(size_in; benchmark=true)
     MPI.Barrier(comm)
 end
 
-function main()
-    MPI.Init()
+MPI.Initialized() || MPI.Init()
+silence_stdout(MPI.COMM_WORLD)
 
-    silence_stdout(MPI.COMM_WORLD)
-
-    test_rfft(DATA_DIMS_EVEN)
-    println()
-    test_rfft(DATA_DIMS_ODD, benchmark=false)
-
-    MPI.Finalize()
-end
-
-main()
+test_rfft(DATA_DIMS_EVEN)
+println()
+test_rfft(DATA_DIMS_ODD, benchmark=false)


### PR DESCRIPTION
There is no reason why a `Pencil` configuration should include element type information.

For compatibility, an element type will still be encoded into `Pencil` for the next few versions, but `eltype(::Pencil)` will display a deprecation warning.