### PR TITLE
Update multiarrays_r2c.jl

### DIFF
--- a/src/multiarrays_r2c.jl
+++ b/src/multiarrays_r2c.jl
@@ -5,7 +5,7 @@ import PencilArrays: AbstractManyPencilArray, _make_arrays
     ManyPencilArrayRFFT!{T,N,M} <: AbstractManyPencilArray{N,M}
 
 Container holding `M` different [`PencilArray`](https://jipolanco.github.io/PencilArrays.jl/dev/PencilArrays/#PencilArrays.PencilArray) views to the same
-underlying data buffer. All views share the same and dimensionality `N`.
+underlying data buffer. All views share the same dimensionality `N`.
 The element type `T` of the first view is real, that of subsequent views is 
 `Complex{T}`. 
 
@@ -72,7 +72,7 @@ function _make_real_array(data, extra_dims, p)
     dims = (dims_padded_local..., extra_dims...)
     axes_local = (Base.OneTo.(dims_space_local)..., Base.OneTo.(extra_dims)...)
     n = prod(dims)
-    vec = view(data, Base.OneTo(n))
+    vec = unsafe_wrap(typeof(data), pointer(data), n) # fixes efficiency issues with vec = view(data, Base.OneTo(n))
     parent_arr = reshape(vec, dims)
     arr = view(parent_arr, axes_local...)
     PencilArray(p, arr)


### PR DESCRIPTION
Hi,

I propose a minor update of `multiarrays_r2c.jl` to fix two issues for the use of the view to the first (real valued) `PencilArray` of the `ManyPencilArraysRFFT!`. 

Since the input real valued array of a `RFFT` uses less memory than the complex output, the inplace `RFFT!` requires that the view to the real valued array is reshaped from a vector SubArray `vec` of some larger vector `data`. This was previously done using `vec = view(data, Base.OneTo(n))`. 

However `reshape(vec, dims)` outputs a `Base.ReshapedArray{T, N, SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int64}}, true}, Tuple{}}`, for which the compiler may produce inefficient code. 

The proposed alternative is to use `vec = unsafe_wrap(typeof(data), pointer(data), n)`, after which `reshape(vec, dims)` outputs a simple `Array{T,N}`. 

This fixes:
1. Some performance issues for the use of the real valued `PencilArray` view of the `ManyPencilArraysRFFT!`
2. Error while saving the real valued `PencilArray` view using `PencilArrays.PencilIO`

The same idea could be used in function `_make_arrays` of [`multiarrays.jl`](https://github.com/jipolanco/PencilArrays.jl/blob/master/src/multiarrays.jl) of `PencilArrays`, line 137: `vec = view(data, Base.OneTo(n))`.